### PR TITLE
chg: remove ssh_private_key from workflows.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,36 +34,29 @@ jobs:
         with:
           repository: zapatacomputing/orquestra-quantum
           path: orquestra-quantum
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-opt
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-opt
           path: orquestra-opt
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-vqa
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-vqa
           path: orquestra-vqa
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-cirq
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-cirq
           path: orquestra-cirq
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-qiskit
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-qiskit
           path: orquestra-qiskit
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - uses: ./subtrees/z_quantum_actions/actions/coverage
-        with:
-          codecov_secret: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -20,49 +20,36 @@ jobs:
           # version.
           fetch-depth: 0
 
-      # ------------------------------------------------------------------------
-      # Loads private SSH key to the SSH agent. Allows to install dependencies 
-      # from private git repos, but requires setting `secrets.SSH_PRIVATE_KEY`
-      # in repo settings.
-      # ------------------------------------------------------------------------
-      - uses: ./subtrees/z_quantum_actions/actions/ssh_setup
-        with:
-          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-quantum
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-quantum
           path: orquestra-quantum
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-opt
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-opt
           path: orquestra-opt
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-vqa
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-vqa
           path: orquestra-vqa
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-cirq
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-cirq
           path: orquestra-cirq
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-qiskit
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-qiskit
           path: orquestra-qiskit
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Run publish release action
         uses: ./subtrees/z_quantum_actions/actions/publish-release

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -34,35 +34,30 @@ jobs:
         with:
           repository: zapatacomputing/orquestra-quantum
           path: orquestra-quantum
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-opt
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-opt
           path: orquestra-opt
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-vqa
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-vqa
           path: orquestra-vqa
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-cirq
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-cirq
           path: orquestra-cirq
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Get orquestra-qiskit
         uses: actions/checkout@v2
         with:
           repository: zapatacomputing/orquestra-qiskit
           path: orquestra-qiskit
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       # Installs project, checks codestyle
       - uses: ./subtrees/z_quantum_actions/actions/style


### PR DESCRIPTION
Given all the repos are public, removing `SSH_PRIVATE_KEY` as it's unnecessary and might just cause confusion in future.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.