### PR TITLE
feat: added CONTRIBUTING and CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the team leader responsible for enforcement at
+[michal.stechly@zapatacomputing.com](mailto:michal.stechly@zapatacomputing.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Orquestra
+
+🎶 Thanks so much for your interest in contributing to Orquestra! 🎶
+
+We at Zapata's quantum software team value contributions to orquestra, so we created this document to guide you from planning your code all the way to making a PR. But if you have more questions, please feel free to email our engineers [michal](mailto:michal.stechly@zapatacomputing.com) of [athena](mailto:athena.caesura@zapatacomputing.com) for some guidance. 
+
+## Code of Conduct
+
+Contributors to the orquestra project are expected to follow the orquestra [code of conduct](CODE_OF_CONDUCT.md). Please report violations to either of our engineers listed above.
+
+## How to Contribute
+
+### Choosing an Issue
+
+For new contributors, the good-first-issue tag is usually a great place to start!
+
+### Installation
+
+After cloning the repository, run `pip install -e .[dev]` from the main directory to install the development version. Note that in certain environments you might need to add quotes: `pip install -e '.[dev]'`. This install will ensure you have all the dependencies you need in order to contribute to Orquestra.
+
+### Commits
+
+Zapata's QS team uses the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) style for commit messages so that we can automatically generate release notes.
+
+### Comments
+
+We use [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstring format. If you'd like to specify types please use [PEP 484](https://www.python.org/dev/peps/pep-0484/) type hints instead adding them to docstrings.
+
+### Style
+
+Orquestra contributors are required to use black, flake8, mypy and isort to run automated checks for code style. Make sure to install the development version (described above) so you can run these commands using the `make style` command or [pre-commit hooks](https://pre-commit.com/).
+
+### Tests
+
+All new contributions to Orquestra should be accompanied by deterministic unit tests. This means each test should focus on a specific aspect of the new code and shouldn't include any probabilistic elements. If you are unsure how to remove randomness in your tests, mention it in your PR and we'll be happy to assist. 💪
+
+Tests for this project can be run using the `make coverage` or `pytest .` commands from the main directory.
+
+### Making a PR
+
+Before submitting your PR, run `make muster` from the main directory. This ensures your code will pass tests and style once submitted.
+
+When your code passes muster, ensure your changes are on a new branch whose name describes the issue you are solving.
+
+Then you can make a PR directly to the `main` branch by filling out the PR submission template and clicking create pull request.
+
+When you make your PR, github will automatically run style and test checks on python 3.8, 3.9, and 3.10 using [Github Actions](.github/workflows/style.yml). While tests are running, request that `quantum-software` to review your code.
+
+Once you have made the requested changes and your PR is approved, you can click merge and delete your branch. 🎉
+
+### Bug Reporting
+
+If you'd like to report a bug/issue please create a new issue in this repository.
+
+## Tips
+
+### Modular Design
+
+Here at Zapata's QS team we're all about connecting computers. Our Orquestra software is intended to act as a bridge between others including pyquil, cirq, qiskit, and qulacs. This flexibility gives our scientists access to a wide variety of platforms from which to conduct experiments.
+
+As a result, we make extensive use of modular interfaces such as [protocols](https://peps.python.org/pep-0544/) in our codebase. Familiarizing yourself with protocols will greatly enhance your understanding of our design and improve the your contributions.
+
+### Tests
+
+If you implement an interface, chances are we have already written some tests for it. For instance if you were to implement a new `QuantumBackend`, you should take advantage of the tests in `QuantumBackendTests`. This means that the tests you write can be specific to your new implementation and can save a lot of time!
+
+Tests not only to ensure the code is functional, but will also tells us a lot about your implementation. Don't let your code go in alone! Give it some nice tests to keep it company! 👭
+
+Most importantly, don't be afraid to use our tests as inspiration for your own!
+
+## Ending Note 🎵
+
+Thanks again for contributing!
+
+We're hiring! So check out our job listings on our [website](https://www.zapatacomputing.com/quantum-computing-careers/)!
+
+🔥 Can't wait to see your PRs 🔥

--- a/README.md
+++ b/README.md
@@ -49,22 +49,9 @@ pip install orquestra-opt[qubo]
 For examples and tutorials please refer to [the documentation](https://zapatacomputing.github.io/orquestra-core/).
 
 
-## Development and Contribution
+## Bug Reporting
 
-To install the development version, run `pip install -e .[dev]` from the main directory. Note that in certain environments you might need to add quotes: `pip install -e '.[dev]'`.
+If you'd like to report a bug/issue please create a new issue in this repository.
 
-We use [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstring format. If you'd like to specify types please use [PEP 484](https://www.python.org/dev/peps/pep-0484/) type hints instead adding them to docstrings.
-
-There are codestyle-related [Github Actions](.github/workflows/style.yml) running for all pull requests.
-
-- If you'd like to report a bug/issue please create a new issue in this repository.
-- If you'd like to contribute, please create a pull request.
-
-### Running tests
-
-Unit tests for this project can be run using `make coverage` command from the main directory.
-Alternatively you can also run `pytest .`.
-
-### Style
-
-We are using automatic tools for style and type checking. In order to make sure the code is compliant with them please run: `make style` from the main directory (this requires `dev` dependencies).
+## Contributing
+Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for more information on contributing to Orquestra.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For examples and tutorials please refer to [the documentation](https://zapatacom
 
 ## Bug Reporting
 
-If you'd like to report a bug/issue please create a new issue in this repository.
+If you'd like to report a bug/issue please create a new issue in appropriate repository. When in doubt, feel free to create issue in this repo.
 
 ## Contributing
-Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for more information on contributing to Orquestra.
+Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for more information on contributing to Orquestra Core.


### PR DESCRIPTION
## Description

Needed to add guidelines for contributing as we are likely to get more opensource contributors. I created a CONTRIBUTING.md loosely based on [atom's version](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) and added the contributor code of conduct version 2.1.

## Please verify that you have completed the following steps

- [x] I have updated documentation.
