### PR TITLE
docs(fix): API docs now line wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/tutorials/images/.DS_Store
 docs/repos/
 docs/api/
 docs/tmp_monorepo/
+docs/.DS_Store

--- a/docs/_static/css/autoapi.css
+++ b/docs/_static/css/autoapi.css
@@ -1,0 +1,5 @@
+.table.autosummary td:first-child {
+  max-width: 45vw;
+  white-space: normal;
+  word-wrap: break-word;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,3 +165,8 @@ autoapi_options = [
     "imported-members",
     "undoc-members",
 ]
+
+
+# uses a custom CSS file to override some defaults
+def setup(app):
+    app.add_css_file("css/autoapi.css")


### PR DESCRIPTION
## Description

- Context: why is it needed? In case of bug, what was the cause for the bug?
  - The API docs had some weird formatting where tables containing long function signatures (usually involving many type hints) wouldn't get wrapped, instead they would just increase the width of the page
- Concise description of the implemented solution.
  - Overriding the CSS that controls the autogenerated table's max width to be 45% of the view window. For some reason making it a percent of the parent element (with `45%` instead of `45vw`) led to the same issue as before.
- If any dependencies are added, list them and justify why they are needed.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
