### PR TITLE
Zqs 1146/remove forest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,12 +59,6 @@ jobs:
           repository: zapatacomputing/orquestra-qiskit
           path: orquestra-qiskit
           
-      - name: Get orquestra-forest
-        uses: actions/checkout@v2
-        with:
-          repository: zapatacomputing/orquestra-forest
-          path: orquestra-forest
-
       - name: Get orquestra-qulacs
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -59,12 +59,6 @@ jobs:
           repository: zapatacomputing/orquestra-qiskit
           path: orquestra-qiskit
 
-      - name: Get orquestra-forest
-        uses: actions/checkout@v2
-        with:
-          repository: zapatacomputing/orquestra-forest
-          path: orquestra-forest
-
       - name: Get orquestra-qulacs
         uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ github_actions:
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-opt[cma] && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-vqa && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-qiskit && \
-		${VENV_NAME}/bin/python3 -m pip install ./orquestra-forest && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-cirq[qsim] && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-qulacs
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Orquestra Core comprises of the following packages:
 
 * [`orquestra-qiskit`](https://github.com/zapatacomputing/orquestra-qiskit) – integration with [qiskit](https://qiskit.org/).
 * [`orquestra-cirq`](https://github.com/zapatacomputing/orquestra-cirq) – integration with [CirQ](https://quantumai.google/cirq).
-* [`orquestra-forest`](https://github.com/zapatacomputing/orquestra-forest) – integration with [Forest SDK](https://docs.rigetti.com/qcs/).
 * [`orquestra-qulacs`](https://github.com/zapatacomputing/orquestra-qulacs) – integration with [Qulacs simulator](http://docs.qulacs.org/en/latest/).
+
+We have temporarily removed [`orquestra-forest`](https://github.com/zapatacomputing/orquestra-forest) (integration with [Forest SDK](https://docs.rigetti.com/qcs/)) due to compatibility issues. It should work in most cases, if you need it feel free to install it manually.
 
 
 ## Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     orquestra-vqa==0.4.0
     orquestra-qiskit==0.4.0
     orquestra-cirq==0.4.0
-    orquestra-forest==0.3.0
     orquestra-qulacs==0.3.0
 
 [options.packages.find]


### PR DESCRIPTION
## Description

Removing `orquestra-forest` from `orquestra-core` package in order to avoid dependency issues with some of the other libraries we are using.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
- [X] I have updated documentation.
