### PR TITLE
one bug fix and update to make all includes relative.  

### DIFF
--- a/docs/guides/circuits.rst
+++ b/docs/guides/circuits.rst
@@ -83,7 +83,7 @@ Now let's inspect some aspects of the unitary of the circuit, just as a sanity c
   :start-at: unitary = state_prep_circ.to_unitary()
   :end-at: ic(type(unitary))
 
-.. include:: /tutorials/beginner_tutorial.rst
+.. include:: ../tutorials/beginner_tutorial.rst
     :start-after: icecream-note:
     :end-before: This will output a text description of the circuit
 

--- a/docs/tutorials/basic_qaoa.rst
+++ b/docs/tutorials/basic_qaoa.rst
@@ -43,7 +43,7 @@ Let's start by creating a new python file called ``qaoa_maxcut.py``. The first t
     :start-at: from collections import Counter
     :end-at: from icecream import ic
 
-.. include:: /tutorials/beginner_tutorial.rst
+.. include:: ../tutorials/beginner_tutorial.rst
     :start-after: icecream-note:
     :end-before: This will output a text description of the circuit
 

--- a/docs/tutorials/contributing.rst
+++ b/docs/tutorials/contributing.rst
@@ -6,9 +6,9 @@ Contributing to Orquestra Core
 
 Orquestra Core itself doesn't have any source code in it, so the first step is to find which specific package you want to contribute to:
 
-.. include:: /tutorials/orq_core_structure.rst
+.. include:: ../tutorials/orq_core_structure.rst
   :start-after: Orquestra Core is broken into multiple packages, each with a different purpose.
-  :end-before: Here is a diagram of these packages:
+  :end-line: 31
 
 Now that you've found the repository you want to contribute to, you can fork it and make your edits, or open a new issue for that repo.
 

--- a/docs/tutorials/integrations.rst
+++ b/docs/tutorials/integrations.rst
@@ -17,7 +17,7 @@ Ansatzes
 * `HEAQuantumCompilingAnsatz <https://github.com/zapatacomputing/orquestra-vqa/blob/main/tests/orquestra/vqa/ansatz/quantum_compiling_test.py>`_
 * `SingletUCCSDAnsatz <https://github.com/zapatacomputing/orquestra-vqa/blob/main/tests/orquestra/vqa/ansatz/singlet_uccsd_test.py>`_
 
-.. include:: /guides/backends.rst
+.. include:: ../guides/backends.rst
   :start-after: .. _integrated_backends:
   :end-before: Conversions to other frameworks
 


### PR DESCRIPTION
prep for inclusion into orquestra-docs-private

## Description

This pull request fixes one bug where an internal inclusion had an incorrect end-before.  it caused missing content
It also moves the paths for some include calls to be relative.  This means they continue to work when docs content is included into other docs such as orquestra-docs-private.

I have built locally to confirm it works
