### PR TITLE
chore: unpin orquestra-sdk

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     orquestra-quantum==0.9.0
     orquestra-opt==0.7.0
     orquestra-vqa==0.8.0
-    orquestra-sdk==0.43.0
+    orquestra-sdk>=0.42.0
 
 
 
@@ -41,7 +41,7 @@ dev =
     orquestra-qulacs==0.7.0
     orquestra-cirq==0.8.0
     orquestra-braket==0.3.0
-    orquestra-sdk[all]==0.43.0
+    orquestra-sdk[all]>=0.42.0
     orqviz==0.4.0
     icecream
 
@@ -67,7 +67,7 @@ all =
     orquestra-qulacs==0.7.0
     orquestra-cirq==0.8.0
     orquestra-braket==0.3.0
-    orquestra-sdk[all]==0.43.0
+    orquestra-sdk[all]>=0.42.0
     orqviz==0.4.0
 
 orqviz =


### PR DESCRIPTION
## Description

We have conflicts between `orquestra-core` and `orquestra-sdk` sometimes.

This unpins `orquestra-sdk`, allowing all versions after the first public release.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
