### PR TITLE
fix(docs): ZQS-1347-fix-basic-circuits-section

### DIFF
--- a/docs/quantum/tutorials/beginner_tutorial.rst
+++ b/docs/quantum/tutorials/beginner_tutorial.rst
@@ -25,13 +25,13 @@ This state can be created using a Hadamard gate and a CNOT gate:
     q_1: ─────┤ X ├
               └───┘
 
-Let's create a circuit that does this for us! Create a new file ``bell_state.py`` and follow along
+Let's create a circuit that does this for us! Create a new file ``bell_state.py`` and follow along with these steps ↓
 
 This circuit can be created in a few lines. First, we import the needed gate and circuit classes, then create a new ``Circuit`` object, and finally add the gates we want.
 
 .. literalinclude:: ../examples/tutorials/bell_state.py
     :language: python
-    :start-at: from orquestra.quantum.circuits import CNOT, H, Circuit
+    :start-at: # build the circuit
     :end-at: ic(bell_circuit)
 
 .. _icecream-note:


### PR DESCRIPTION
## Description

- Context:
  - one section of the code didn't render after the order of imports in [bell_state.py was changed](https://github.com/zapatacomputing/orquestra-core/commit/7ba7c98142f22d0ab50a174eb3a328f7a6c7eda9#diff-9a57faa5a6ca162eb041ac8e39208cbc7200f70730468e9789032d499edb8df6R8) in 7ba7c98142f22d0ab50a174eb3a328f7a6c7eda9
  - The grammar of "and follow along" has been there since the first iteration.
- Changed the beginning of the `literalinclude` to be the comment above the import. Makes it a bit more robust for the future

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
