### PR TITLE
chore: remove docs deps pin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,8 +4,6 @@ sphinx-copybutton
 sphinx-design
 sphinxemoji
 Jinja2>=3.0.0
-protobuf==3.20.1
-Pygments==2.11.2
 
 git+https://git@github.com/zapatacomputing/orquestra-manifest.git
 


### PR DESCRIPTION
This pinning is no longer required

## Description

- Context: it used to be needed to get around certain versions of furo+sphinx not working. that issue has been fixed, so we're good to unpin!

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
